### PR TITLE
Change Index Criteria to Not Allow Floats. Add Tests.

### DIFF
--- a/src/Views/ArrayView.php
+++ b/src/Views/ArrayView.php
@@ -290,7 +290,13 @@ class ArrayView implements ArrayViewInterface
      */
     private function numericOffsetExists($offset): bool
     {
-        if (!\is_string($offset) && \is_numeric($offset) && (\is_nan($offset) || \is_infinite($offset))) {
+        // Non-string must be integer
+        if (!\is_string($offset) && !\is_int($offset)) {
+            return false;
+        }
+
+        // Numeric string must be 'integer'
+        if (\is_string($offset) && \preg_match('/^-?\d+$/', $offset) !== 1) {
             return false;
         }
 

--- a/tests/unit/ArrayView/IndexTest.php
+++ b/tests/unit/ArrayView/IndexTest.php
@@ -287,7 +287,7 @@ class IndexTest extends \Codeception\Test\Unit
      * @param mixed $i
      * @return void
      */
-    public function testNonIntegerIndexError($i): void
+    public function testNonIntegerKeyError($i): void
     {
         // Given
         $array = [10, 20, 30];
@@ -310,6 +310,39 @@ class IndexTest extends \Codeception\Test\Unit
             ['④'],
             ['V'],
             ['six'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForFloatIndexes
+     * @param mixed $i
+     * @return void
+     */
+    public function testNonIntegerIndexError($i): void
+    {
+        // Given
+        $array = [10, 20, 30];
+        $arrayView = ArrayView::toView($array);
+
+        // Then
+        $this->expectException(IndexError::class);
+
+        // When
+        $number = $arrayView[$i];
+    }
+
+    public static function dataProviderForFloatIndexes(): array
+    {
+        return [
+            [0.1],
+            ['0.5'],
+            ['1.5'],
+            [2.0],
+            [3.1],
+            ['45.66'],
+            [\NAN],
+            [\INF],
+            [-\INF],
         ];
     }
 }


### PR DESCRIPTION
I tightened up the logic for what a valid index is. The previous logic allowed floats, but it did not seem like float indexes made sense, as PHP cannot have floats as an array index, and the previous behavior was casting the float to an int and using that as the index value. 

```php
return $this->source[$this->convertIndex(\intval($offset))];
```

Consider if this is the behavior you want.

For reference, if you cast a float to an int:
```php
php > echo intval(1.4);
1
php > echo intval(1.5);
1
php > echo intval(1.9);
1
php > echo intval(-1.9);
-1
```

Added some tests to show that floats and numeric floats as well as special floats no longer work.

For reference in Python:
```python
>>> [1, 2, 3][1.5]
<stdin>:1: SyntaxWarning: list indices must be integers or slices, not float; perhaps you missed a comma?
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: list indices must be integers or slices, not float
```

Also, it was not clear what the distinction between `KeyError` and `IndexError` is. The unit tests assert what is currently being thrown.